### PR TITLE
added a command for enabling and disabling the glow state with /lockglow

### DIFF
--- a/src/main/java/de/lockcard/essentials/Main.java
+++ b/src/main/java/de/lockcard/essentials/Main.java
@@ -1,13 +1,31 @@
 package de.lockcard.essentials;
 
+import de.lockcard.essentials.commands.GlowCommand;
 import de.lockcard.essentials.listener.PlayerJoinListener;
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class Main extends JavaPlugin {
+    private static Plugin plugin;
 
     @Override
     public void onEnable() {
+        Main.plugin = this;
+        saveDefaultConfig();
         Bukkit.getPluginManager().registerEvents(new PlayerJoinListener(), this);
+        GlowCommand glowCommand = new GlowCommand();
+        getCommand("lockglow").setExecutor(glowCommand);
+        getCommand("lockglow").setTabCompleter(glowCommand);
+    }
+
+    public static String getMessage(String path) {
+        String message = "";
+        message += plugin.getConfig().getString("Messages.Prefix", "");
+        message += plugin.getConfig().getString("Messages." +path, "");
+        message = ChatColor.translateAlternateColorCodes('&', message);
+
+        return message;
     }
 }

--- a/src/main/java/de/lockcard/essentials/commands/GlowCommand.java
+++ b/src/main/java/de/lockcard/essentials/commands/GlowCommand.java
@@ -1,0 +1,86 @@
+package de.lockcard.essentials.commands;
+
+import de.lockcard.essentials.Main;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.bukkit.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class GlowCommand implements CommandExecutor, TabCompleter {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+
+        switch (args.length) {
+                // lockglow
+            case 0:
+                if(!sender.hasPermission("glow.self")) {
+                    sender.sendMessage(Main.getMessage("NoPermission"));
+                    return true;
+                }
+
+                if(!(sender instanceof Player player))
+                    return false;
+
+                player.setGlowing(!player.isGlowing());
+
+                //Message Output
+                player.sendMessage(getGlowMessage(player));
+                break;
+
+                // lockglow [Player]
+            case 1:
+                if (!sender.hasPermission("glow.other")) {
+                    sender.sendMessage(Main.getMessage("NoPermission"));
+                    return true;
+                }
+
+                Player target = Bukkit.getPlayer(args[0]);
+                if (target == null) {
+                    sender.sendMessage(Main.getMessage("PlayerNotFound").replace("%name%", args[0]));
+                    return true;
+                }
+
+                target.setGlowing(!target.isGlowing());
+
+                //Message Output
+                target.sendMessage(getGlowMessage(target));
+                sender.sendMessage(getGlowMessageOther(target));
+                break;
+
+            default:
+                return false;
+        }
+
+        return true;
+    }
+
+    private String getGlowMessage(Player target) {
+        return Main.getMessage(target.isGlowing() ? "GlowSelf.Enable" : "GlowSelf.Disable");
+    }
+
+    private String getGlowMessageOther(Player target) {
+        return Main.getMessage(target.isGlowing() ? "GlowOther.Enable" : "GlowOther.Disable").replace("%name%", target.getName());
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String label, String[] args) {
+        List<String> commands = new ArrayList<>();
+        List<String> completions = new ArrayList<>();
+
+        if(args.length == 1 && sender.hasPermission("glow.other")) {
+            Bukkit.getOnlinePlayers().forEach(player -> commands.add(player.getName()));
+        }
+
+        StringUtil.copyPartialMatches(args[args.length - 1], commands, completions);
+        Collections.sort(completions);
+        return completions;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,10 @@
+Messages:
+  Prefix: "[Lockcraft-Essentials] "
+  NoPermission: "Dir fehlen die erforderlichen Berechtigungen um diesen Befehl auszuführen"
+  PlayerNotFound: "Der Spieler %name% konnte nicht gefunden werden"
+  GlowSelf:
+    Enable: "Du leuchtest nun"
+    Disable: "Du hast aufgehört zu leuchten"
+  GlowOther:
+    Enable: "Der Spieler %name% leuchtet nun"
+    Disable: "Der Spieler %name% hat aufgehört zu leuchten"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,24 @@
 name: LockcardEssentials
-version: 1.0
-author: SirSpigotAPI
+version: 1.1
+authors:
+  - SirSpigotAPI
+  - zorryno
 main: de.lockcard.essentials.Main
 commands:
+  lockglow:
+    usage: "/lockglow [Player]"
+    description: "Enable/Disable glowing"
+permissions:
+  glow.*:
+    description: "All glow permissions"
+    default: op
+    children:
+      - glow.self
+      - glow.other
+  glow.self:
+    description: "Enable/Disable glowing for yourself"
+    default: true
+  glow.other:
+    description: "Enable/Disable glowing for others"
+    default: op
 


### PR DESCRIPTION
Funktion wie in https://discord.com/channels/1058010548106694736/1065687720283885630 angefragt wurde hinzugefügt und mit der Permission "glow.self" und "glow.other" zur Verfügung gestellt
die Permission "glow.*" vergibt alle glow Permissions
Nachrichten sind mithilfe der Config einstellbar bei Rückfragen gerne melden